### PR TITLE
Add Telegram salon admin calendar features

### DIFF
--- a/booking/api/urls.py
+++ b/booking/api/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
 from booking.api.views import (
+    AdminAppointmentStatusView,
+    AdminAppointmentsView,
+    AdminProfileView,
     AppointmentListCreateView,
     AvailableSlotsView,
     CityListView,
@@ -22,4 +25,11 @@ urlpatterns = [
     path("stylists/<int:stylist_id>/services/", StylistServiceListView.as_view(), name="api-stylist-services"),
     path("stylists/<int:stylist_id>/slots/", AvailableSlotsView.as_view(), name="api-available-slots"),
     path("appointments/", AppointmentListCreateView.as_view(), name="api-appointments"),
+    path("admin/profile/", AdminProfileView.as_view(), name="api-admin-profile"),
+    path("admin/appointments/", AdminAppointmentsView.as_view(), name="api-admin-appointments"),
+    path(
+        "admin/appointments/<int:pk>/status/",
+        AdminAppointmentStatusView.as_view(),
+        name="api-admin-appointment-status",
+    ),
 ]

--- a/booking/telebot.py
+++ b/booking/telebot.py
@@ -6,15 +6,19 @@ from django.conf import settings
 
 BOT_TOKEN = settings.TELEGRAM_BOT_TOKEN
 
+ASYNC_DEFAULT_PROPERTIES = DefaultBotProperties(parse_mode="HTML")
+
+
 async def _send(chat_id_or_username: str, text: str):
     bot = Bot(
         BOT_TOKEN,
-        default=DefaultBotProperties(parse_mode="HTML")
+        default=ASYNC_DEFAULT_PROPERTIES,
     )
     try:
         await bot.send_message(chat_id_or_username, text)
     finally:
         await bot.session.close()
+
 
 def send_telegram(chat_id: int = None, username: str = None, text: str = ""):
     """


### PR DESCRIPTION
## Summary
- add authenticated admin API endpoints for salon profile lookup, daily appointments, and status updates
- extend the Telegram bot with an admin panel, month calendar picker, and per-appointment status controls for salon admins
- clean up Telegram sending helper return value

## Testing
- python manage.py check *(fails: Django is not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d36569e508321ac5aa30694fd9bcb)