### PR TITLE
Improve salon admin Telegram experience

### DIFF
--- a/booking/api/views.py
+++ b/booking/api/views.py
@@ -430,6 +430,7 @@ class AdminAppointmentStatusView(APIView):
         status_map = {
             "confirm": Appointment.Status.CONFIRMED,
             "cancel": Appointment.Status.CANCELLED,
+            "done": Appointment.Status.DONE,
         }
 
         if action not in status_map:


### PR DESCRIPTION
## Summary
- update the Telegram bot admin panel to use reply keyboard buttons and hide other salons from salon admins
- add status completion option and shared helpers for updating appointments, including notifications to admins about new bookings
- extend admin status API support for marking appointments as done

## Testing
- python -m compileall booking

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3b6f08388321bf3539e0b7ac3c54)