### PR TITLE
Add confirmation flow for admin appointment cancellations

### DIFF
--- a/booking/api/views.py
+++ b/booking/api/views.py
@@ -437,6 +437,11 @@ class AdminAppointmentStatusView(APIView):
             return Response({"detail": "Недопустимый статус."}, status=status.HTTP_400_BAD_REQUEST)
 
         new_status = status_map[action]
+        if appointment.status in {Appointment.Status.CANCELLED, Appointment.Status.DONE} and appointment.status != new_status:
+            return Response(
+                {"detail": "Статус уже финальный и не может быть изменён."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         appointment.status = new_status
         updates = appointment.update_payment_status_for_status(new_status)
         update_fields = ["status"] + updates


### PR DESCRIPTION
## Summary
- add inline confirmation before cancelling appointments in the Telegram bot and hide actions for final statuses
- notify salon admins with actionable keyboards on new bookings and adjust available actions based on appointment status
- prevent further status changes for cancelled or completed appointments at the API level

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d40b5922c83218a1a0c5d7e153b38)